### PR TITLE
Use testcontainers - allow placeholders in config

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 0.1.2
+current_version = 0.1.3
 
 [bumpversion:file:pyproject.toml]
 search = version = "{current_version}"

--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,1 @@
+OCF_PV_DB_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Environment
+.env

--- a/Makefile
+++ b/Makefile
@@ -11,21 +11,6 @@ format:
 	poetry run isort $(SRC)
 	poetry run black $(SRC)
 
-# TODO Use testcontainers instead.
-.PHONY: test-db
-test-db:
-	docker kill psp-test-db; true
-	docker run \
-		-it --rm \
-		-d \
-		--name psp-test-db \
-		-e POSTGRES_USER=postgres-test \
-		-e POSTGRES_PASSWORD=postgres-test \
-		-e POSTGRES_DB=psp-test \
-		-p 5460:5432 \
-		postgres:13-alpine
-
 .PHONY: test
-test: test-db
+test:
 	poetry run pytest --cov=pv_site_production tests --cov-report xml $(ARGS)
-	docker kill psp-test-db; true

--- a/configurations/aws_conf.yaml
+++ b/configurations/aws_conf.yaml
@@ -1,0 +1,11 @@
+run_model_func: pv_site_production.models.psp.psp_model.get_model
+model_path: dev_model.pkl
+
+nwp:
+  cls: pv_site_production.data.nwp_data_sources.NwpDataSource
+  kwargs:
+    path: s3://nowcasting-nwp-development/data/latest.netcdf
+
+pv_metadata_path: ./meta_inferred.csv
+
+pv_db_url: ${OCF_PV_DB_URL}

--- a/poetry.lock
+++ b/poetry.lock
@@ -829,6 +829,43 @@ files = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+description = "A library to handle automated deprecations"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"},
+    {file = "deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff"},
+]
+
+[package.dependencies]
+packaging = "*"
+
+[[package]]
+name = "docker"
+version = "6.0.1"
+description = "A Python library for the Docker Engine API."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "docker-6.0.1-py3-none-any.whl", hash = "sha256:dbcb3bd2fa80dca0788ed908218bf43972772009b881ed1e20dfc29a65e49782"},
+    {file = "docker-6.0.1.tar.gz", hash = "sha256:896c4282e5c7af5c45e8b683b0b0c33932974fe6e50fc6906a0a83616ab3da97"},
+]
+
+[package.dependencies]
+packaging = ">=14.0"
+pywin32 = {version = ">=304", markers = "sys_platform == \"win32\""}
+requests = ">=2.26.0"
+urllib3 = ">=1.26.0"
+websocket-client = ">=0.32.0"
+
+[package.extras]
+ssh = ["paramiko (>=2.4.3)"]
+
+[[package]]
 name = "einops"
 version = "0.6.0"
 description = "A new flavour of deep learning operations"
@@ -3219,6 +3256,21 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "0.21.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python-dotenv-0.21.1.tar.gz", hash = "sha256:1c93de8f636cde3ce377292818d0e440b6e45a82f215c3744979151fa8151c49"},
+    {file = "python_dotenv-0.21.1-py3-none-any.whl", hash = "sha256:41e12e0318bebc859fcc4d97d4db8d20ad21721a6aa5047dd59f090391cb549a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pytorch-lightning"
 version = "1.9.0"
 description = "PyTorch Lightning is the lightweight PyTorch wrapper for ML researchers. Scale your models. Write less boilerplate."
@@ -3810,6 +3862,40 @@ pure-eval = "*"
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
+name = "testcontainers"
+version = "3.7.1"
+description = "Library provides lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "testcontainers-3.7.1-py2.py3-none-any.whl", hash = "sha256:7f48cef4bf0ccd78f1a4534d4b701a003a3bace851f24eae58a32f9e3f0aeba0"},
+]
+
+[package.dependencies]
+deprecation = "*"
+docker = ">=4.0.0"
+wrapt = "*"
+
+[package.extras]
+arangodb = ["python-arango"]
+azurite = ["azure-storage-blob"]
+clickhouse = ["clickhouse-driver"]
+docker-compose = ["docker-compose"]
+google-cloud-pubsub = ["google-cloud-pubsub (<2)"]
+kafka = ["kafka-python"]
+keycloak = ["python-keycloak"]
+mongo = ["pymongo"]
+mssqlserver = ["pymssql"]
+mysql = ["pymysql", "sqlalchemy"]
+neo4j = ["neo4j"]
+oracle = ["cx-Oracle", "sqlalchemy"]
+postgresql = ["psycopg2-binary", "sqlalchemy"]
+rabbitmq = ["pika"]
+redis = ["redis"]
+selenium = ["selenium"]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.1.0"
 description = "threadpoolctl"
@@ -4061,6 +4147,23 @@ files = [
 ]
 
 [[package]]
+name = "websocket-client"
+version = "1.4.2"
+description = "WebSocket client for Python with low level API options"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "websocket-client-1.4.2.tar.gz", hash = "sha256:d6e8f90ca8e2dd4e8027c4561adeb9456b54044312dba655e7cae652ceb9ae59"},
+    {file = "websocket_client-1.4.2-py3-none-any.whl", hash = "sha256:d6b06432f184438d99ac1f456eaf22fe1ade524c3dd16e661142dc54e9cba574"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=3.4)", "sphinx-rtd-theme (>=0.5)"]
+optional = ["python-socks", "wsaccel"]
+test = ["websockets"]
+
+[[package]]
 name = "wheel"
 version = "0.38.4"
 description = "A built-package format for Python"
@@ -4286,4 +4389,4 @@ jupyter = ["ipytree (>=0.2.2)", "ipywidgets (>=8.0.0)", "notebook"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "298ce83b2fd34568d8b3866b58267db43966bcb970c27bcbc14d5d98583b7a1e"
+content-hash = "a62dc526640bf57ba992d7220c70005ff6c0954cb78e6d3ad8c9b3e98d593139"

--- a/pv_site_production/app.py
+++ b/pv_site_production/app.py
@@ -3,17 +3,19 @@ Apply the model to the PVs in the database and note the results.
 """
 
 import logging
+import os
 import pathlib
 from datetime import datetime
 
 import click
-import yaml
+import dotenv
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.models.base import Base_PV
 from psp.ml.models.base import PvSiteModel
 
 from pv_site_production.data.pv_data_sources import DbPvDataSource
 from pv_site_production.models.common import apply_model
+from pv_site_production.utils.config import load_config
 from pv_site_production.utils.imports import import_from_module
 
 _log = logging.getLogger(__name__)
@@ -47,8 +49,13 @@ def main(
     max_pvs: int | None,
 ):
     """Main function"""
-    with open(config_path) as f:
-        config = yaml.safe_load(f)
+
+    _log.debug("Load the configuration file")
+    # Typically the configuration will contain many placeholders pointing to environment variables.
+    # We allow specifying them in a .env file. See the .env.dist for a list of expected variables.
+    # Environment variables still have precedence.
+    dotenv_variables = dotenv.dotenv_values()
+    config = load_config(config_path, dotenv_variables | os.environ)
 
     if timestamp is None:
         timestamp = datetime.utcnow()

--- a/pv_site_production/utils/config.py
+++ b/pv_site_production/utils/config.py
@@ -1,0 +1,48 @@
+"""
+Utils related to configuration files.
+"""
+
+import pathlib
+import string
+from typing import Any
+
+import yaml
+
+
+# Inspired from:
+# https://dustinoprea.com/2022/04/01/python-substitute-values-into-yaml-during-parse/
+def load_config_from_string(config: str, context: dict[str, str] | None = None) -> Any:
+    """Same as `load_config` but directly from the YAML string."""
+    if context is None:
+        context = {}
+
+    def string_constructor(loader, node):
+        t = string.Template(node.value)
+        value = t.substitute(context)
+        return value
+
+    Loader = yaml.SafeLoader
+    Loader.add_constructor("tag:yaml.org,2002:str", string_constructor)
+
+    token_re = string.Template.pattern
+    Loader.add_implicit_resolver("tag:yaml.org,2002:str", token_re, None)
+
+    return yaml.load(config, Loader=Loader)
+
+
+def load_config(config: pathlib.Path, context: dict[str, str] | None = None) -> Any:
+    """Parse a YAML string config into an object.
+
+    Arguments:
+    ---------
+    config: The configuration file. The contente of the file can contain placeholders like
+        $variable or ${variable}.
+    context: A {key: value} dictionary where the keys are the placeholders variables in the
+        config and where the values are the values we want to replace them with.
+
+    Return:
+    ------
+        The configuration object.
+    """
+    with open(config) as f:
+        return load_config_from_string(f, context)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ pandera = "^0.13.4"
 pandas = "^1.5.2"
 psp = {path = "./pv-site-prediction", develop = true}
 s3fs = "^2022.11.0"
+python-dotenv = "^0.21.1"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -22,6 +23,7 @@ isort = "^5.11.4"
 flake8 = "^6.0.0"
 ipython = "^8.8.0"
 pydocstyle = "^6.3.0"
+testcontainers = "^3.7.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pv-site-production"
-version = "0.1.2"
+version = "0.1.3"
 description = ""
 authors = ["Peter Dudfield"]
 readme = "README.md"

--- a/tests/fixtures/model_configs/cos.yaml
+++ b/tests/fixtures/model_configs/cos.yaml
@@ -1,3 +1,3 @@
 run_model_func: pv_site_production.models.cos.cos_model.get_model
-pv_db_url: "postgresql+psycopg2://postgres-test:postgres-test@localhost:5460/psp-test"
+pv_db_url: ${OCF_PV_DB_URL}
 pv_metadata_path: tests/fixtures/pv_metadata.csv

--- a/tests/fixtures/model_configs/psp.yaml
+++ b/tests/fixtures/model_configs/psp.yaml
@@ -7,7 +7,7 @@ nwp:
 
 model_path: tests/fixtures/psp_model_fixture.pkl
 
-pv_db_url: "postgresql+psycopg2://postgres-test:postgres-test@localhost:5460/psp-test"
+pv_db_url: ${OCF_PV_DB_URL}
 
 # This should eventually live in the database but we have some inferred metadata in there.
 pv_metadata_path: tests/fixtures/pv_metadata.csv

--- a/tests/models/psp/test_psp.py
+++ b/tests/models/psp/test_psp.py
@@ -1,16 +1,21 @@
 from datetime import datetime
 
 import yaml
+from nowcasting_datamodel.connection import DatabaseConnection
+from nowcasting_datamodel.models.base import Base_PV
 from psp.ml.typings import X
 
 from pv_site_production.data.pv_data_sources import DbPvDataSource
 from pv_site_production.models.psp.psp_model import get_model
 
 
-def test_get_model(db_connection):
+def test_get_model():
     with open("tests/fixtures/model_configs/psp.yaml") as f:
         config = yaml.safe_load(f)
 
+    db_connection = DatabaseConnection(
+        url=config["pv_db_url"], base=Base_PV, echo=False
+    )
     pv_data_source = DbPvDataSource(db_connection, config["pv_metadata_path"])
 
     model = get_model(config, pv_data_source)

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -1,0 +1,25 @@
+from pv_site_production.utils.config import load_config, load_config_from_string
+
+
+def test_load_config_context(tmp_path):
+    context = {"x": "y", "xx": "yy"}
+    config_str = """
+    # Work with ${var} or $var
+    a: ${x}
+    b:
+        c: 123
+        d: $xx
+        e: patate $x poil
+    """
+    config = load_config_from_string(config_str, context)
+    expected = {"a": "y", "b": {"c": 123, "d": "yy", "e": "patate y poil"}}
+
+    assert config == expected
+
+    # Do the same from a file.
+    config_path = tmp_path / "test_load_config_context.yaml"
+    with open(config_path, "w") as f:
+        f.write(config_str)
+
+    config2 = load_config(config_path, context)
+    assert config2 == expected


### PR DESCRIPTION
## Description

* Use the `testcontainers` python library to deal with the test
  database. This somewhat simplifies the tests (especially the makefile).
* Allow ${VARIABLE} placeholers in the config.
* Allow specifying those variables in environment variables and/or in a
  .env file.
* Add a (work in progress) config for our "dev" production environment

## How Has This Been Tested?

* Ran tests
* Added tests
* Ran the `app.py` script on the DEV environment with the provided config

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings

## TODO
- [ ] Merge #15 
- [ ] Make sure the way we deal with placeholders in the config and environment variable is consistent the OCF workflow
- [ ] Review
