### PR TITLE
Write the forecasts to the database

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,10 +12,12 @@ CONFIG_FIXTURES = [
 
 
 @pytest.mark.parametrize("config_file", CONFIG_FIXTURES)
-def test_app(config_file: pathlib.Path):
+@pytest.mark.parametrize("write_to_db", [True, False])
+def test_app(config_file: pathlib.Path, write_to_db: bool):
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["--config", str(config_file), "--date", "2022-1-1-11-50"],
+        ["--config", str(config_file), "--date", "2022-1-1-11-50"]
+        + (["--write-to-db"] if write_to_db else []),
     )
     assert result.exit_code == 0, traceback.print_exception(result.exception)


### PR DESCRIPTION
Write the forecasts to the Database. Since it is easy to to write to the DB by mistake, I added an explicit `--write-to-db` flag.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
