### PR TITLE
Use https for submodule for github actions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pv-site-prediction"]
 	path = pv-site-prediction
-	url = git@github.com:openclimatefix/pv-site-prediction.git
+	url = https://github.com/openclimatefix/pv-site-prediction.git


### PR DESCRIPTION
Otherwise the docker-lease step can't clone the submodule.