### PR TITLE
Set log level to "info" in the prod docker

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -36,4 +36,4 @@ ENV PYTHONPATH=${PYTHONPATH}:/app/pv_site_production
 # Note that we round down the time at which we make the prediction to 15 minutes.
 # This means that if we don't want predictions to be (up-to) 15 minute late,
 # we need to make sure this runs *right after* these "round" times.
-ENTRYPOINT ["poetry", "run", "python", "pv_site_production/app.py", "-c", "configuration.yaml", "--write-to-db", "--round-date-to-minutes", "15", "--log-level", "debug"]
+ENTRYPOINT ["poetry", "run", "python", "pv_site_production/app.py", "-c", "configuration.yaml", "--write-to-db", "--round-date-to-minutes", "15", "--log-level", "info"]

--- a/pv_site_production/app.py
+++ b/pv_site_production/app.py
@@ -177,7 +177,7 @@ def main(
 
     if max_pvs is not None:
         pv_ids = pv_ids[:max_pvs]
-        _log.debug(f"Keeping only {len(pv_ids)} sites")
+        _log.info(f"Keeping only {len(pv_ids)} sites")
 
     for pv_id in pv_ids:
         _run_model_and_save_for_one_pv(


### PR DESCRIPTION
There are simply too many `debug` prints from other packages. `info` sounds like a reasonable place to cut.