### PR TITLE
Add an `ENV` variable to the aws config

### DIFF
--- a/configurations/aws_config.yaml
+++ b/configurations/aws_config.yaml
@@ -1,11 +1,11 @@
 run_model_func: pv_site_production.models.psp.get_model
-model_path: s3://pvsite-ml-models-development/models/model-0.2.0.pkl
+model_path: s3://pvsite-ml-models-${OCF_ENVIRONMENT}/models/model-0.2.0.pkl
 
 nwp:
   cls: psp.data.data_sources.nwp.NwpDataSource
   kwargs:
-    path: s3://nowcasting-nwp-development/data/latest.zarr
+    path: s3://nowcasting-nwp-${OCF_ENVIRONMENT}/data/latest.zarr
 
-pv_metadata_path: s3://pvsite-ml-models-development/meta_inferred.csv
+pv_metadata_path: s3://pvsite-ml-models-${OCF_ENVIRONMENT}/meta_inferred.csv
 
 pv_db_url: ${OCF_PV_DB_URL}


### PR DESCRIPTION
This way we can easily support both 'development' and 'production'.