### PR TITLE
fix: normalize forecast init and horizon timestamps to 15-minute inte…

### DIFF
--- a/forecast-inference/forecast_inference/save/data_platform.py
+++ b/forecast-inference/forecast_inference/save/data_platform.py
@@ -202,11 +202,7 @@ def prepare_forecast_values(
             start_ts = pd.Timestamp(row["start_utc"])
             if start_ts.tz is None:
                 start_ts = start_ts.tz_localize("UTC")
-            start_ts = start_ts.floor("15min")
             horizon_mins = int((start_ts - init_ts).total_seconds() / 60)
-
-        # Round horizon minutes to 15-minute boundaries
-        horizon_mins = int(round(horizon_mins / 15.0) * 15)
 
         p50_fraction = max(0.0, min(1.0, (row["forecast_power_kw"] * 1000) / capacity_watts))
 

--- a/forecast-inference/forecast_inference/save/data_platform.py
+++ b/forecast-inference/forecast_inference/save/data_platform.py
@@ -192,15 +192,21 @@ def prepare_forecast_values(
     init_ts = pd.Timestamp(init_time_utc)
     if init_ts.tz is None:
         init_ts = init_ts.tz_localize("UTC")
+    init_ts = init_ts.floor("15min")
 
     forecast_values: list[dp.CreateForecastRequestForecastValue] = []
     for row in rows:
-        horizon_mins = int(row.get("horizon_minutes", 0))
-        if not horizon_mins:
+        if "horizon_minutes" in row and row["horizon_minutes"] is not None:
+            horizon_mins = int(row["horizon_minutes"])
+        else:
             start_ts = pd.Timestamp(row["start_utc"])
             if start_ts.tz is None:
                 start_ts = start_ts.tz_localize("UTC")
+            start_ts = start_ts.floor("15min")
             horizon_mins = int((start_ts - init_ts).total_seconds() / 60)
+
+        # Round horizon minutes to 15-minute boundaries
+        horizon_mins = int(round(horizon_mins / 15.0) * 15)
 
         p50_fraction = max(0.0, min(1.0, (row["forecast_power_kw"] * 1000) / capacity_watts))
 
@@ -237,20 +243,13 @@ async def save_forecast_to_dataplatform(
     client_location_name = _sanitize(client_location_name)
     energy_source = dp.EnergySource.SOLAR  # UK PV only
 
-    if isinstance(init_time_utc, pd.Timestamp):
-        init_time_utc_dt: datetime = (
-            init_time_utc.tz_localize("UTC") if init_time_utc.tz is None
-            else init_time_utc.tz_convert("UTC")
-        ).to_pydatetime()
+    init_ts = pd.Timestamp(init_time_utc)
+    if init_ts.tz is None:
+        init_ts = init_ts.tz_localize("UTC")
     else:
-        # Use pd.Timestamp as a bridge — .to_pydatetime() always returns a real
-        # datetime, not a FakeDatetime subclass produced by freeze_time.
-        init_time_utc_dt = (
-            pd.Timestamp(init_time_utc)
-            .tz_localize("UTC" if init_time_utc.tzinfo is None else None)
-            if init_time_utc.tzinfo is None
-            else pd.Timestamp(init_time_utc).tz_convert("UTC")
-        ).to_pydatetime()
+        init_ts = init_ts.tz_convert("UTC")
+    init_time_utc_dt: datetime = init_ts.floor("15min").to_pydatetime()
+
 
     log.info(
         "Starting DP save | "


### PR DESCRIPTION
# Align forecast initialization timestamp and horizon steps to 15-minute intervals in Data Platform save logic

## Description

This PR ensures that forecast initialisation timestamps and forecast horizon values saved to the Data Platform are consistently floored and aligned to 15-minute boundaries. Previously, when predictions were triggered with unrounded timestamps, a discrepancy could occur between the floored initialisation time (`init_time_utc_dt`) and the row forecast start times (`start_utc`).

### Key Changes:
- **`forecast_inference/save/data_platform.py`**:
  - Floored `init_time_utc_dt` to 15-minute boundaries (`init_ts.floor("15min")`).
  - In `prepare_forecast_values()`, floored `start_ts` and rounded `horizon_mins` to 15-minute intervals (`0, 15, 30, 45...`).

Fixes #

## How Has This Been Tested?

- Verified `prepare_forecast_values()` outputs monotonically spaced 15-minute horizon steps (`0, 15, 30, 45...`).
- Verified `save_forecast_to_dataplatform()` successfully submits 192 forecast values per site to Data Platform without gRPC validation errors.


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
